### PR TITLE
Fixing issue with date on Nasa apod test

### DIFF
--- a/test/specs/nasa.spec.js
+++ b/test/specs/nasa.spec.js
@@ -19,9 +19,9 @@ describe('Validate APIs on NASA webpage', () => {
         //const APIKey = NasaHomePage.goToNasaAndGetKey();
         NasaHomePage.selectAPIandGo(1);
         var API1 = NasaHomePage.exapmleQuery1.getText();
-        const APIUrl1 = NasaHomePage.treatLink(API1, TestData.APIKey);
+        const APIUrl1 = NasaHomePage.treatLink(API1, TestData.APIKey) + TestData.dateForApod;
         browser.pause(globals.longWait);
-        var output1 = browser.mock('**/' + 'apod?api_key=' + TestData.APIKey, { method: 'get' });
+        var output1 = browser.mock('**/' + 'apod?api_key=' + TestData.APIKey + TestData.dateForApod, { method: 'get' });
 
         browser.url(APIUrl1);
         browser.pause(globals.shortWait);

--- a/test/testData/nasaPage.json
+++ b/test/testData/nasaPage.json
@@ -1,5 +1,6 @@
 {
     "APIKey": "csNg0qm9nHlZKKz5r2e34pIFAx3JiLyidEcZI2QZ",
+    "dateForApod": "&date=2021-07-23",
     "responsePriority": "VeryHigh",
     "responseRefeerPolicy": "strict-origin-when-cross-origin",
     "responseStatusCode": "200",


### PR DESCRIPTION
**Description:**
I had an issue with the first test under /test/specs/nasa.spec.js
It was making the call to the default day (that is the day when the test runs), so i coded it on last friday July 23th, I was expecting those values and when i executed the test today ... the assertions failed because the response it's different since the default day is today.

The fix add the date from last friday to the call, so i'm having now the expected response all the times.